### PR TITLE
Improve handling of antlr parsing errors

### DIFF
--- a/glyles/glycans/poly/anltr_error_listener.py
+++ b/glyles/glycans/poly/anltr_error_listener.py
@@ -1,0 +1,16 @@
+from antlr4.error.ErrorListener import ErrorListener
+from glyles.glycans.utils import ParseError
+import sys
+
+
+class GlyLESErrorListener(ErrorListener):
+
+    def __init__(self):
+        super(GlyLESErrorListener, self).__init__()
+
+    def syntaxError(self, recognizer, offendingSymbol, line, column, msg, e):
+        error_msg = f"line {line}:{column} {msg}"
+        # Printing to stderr kept to mimic the old behaviour.
+        # Maybe not a good idea for a library to pollute the stderr when the exceptions are handled?
+        print(error_msg, file=sys.stderr)
+        raise ParseError(f"Glycan cannot be parsed:\n{error_msg}")

--- a/glyles/glycans/poly/glycan.py
+++ b/glyles/glycans/poly/glycan.py
@@ -420,9 +420,11 @@ class Glycan:
             lexer = GlycanLexer(stream)
             token = CommonTokenStream(lexer)
             parser = GlycanParser(token)
+
             lexer.removeErrorListeners()
-            parser.removeErrorListeners()
             lexer.addErrorListener(GlyLESErrorListener())
+
+            parser.removeErrorListeners()
             parser.addErrorListener(GlyLESErrorListener())
 
             try:

--- a/glyles/glycans/poly/glycan.py
+++ b/glyles/glycans/poly/glycan.py
@@ -1,5 +1,4 @@
 import logging
-import sys
 from collections import Counter
 from typing import Union, List
 
@@ -14,6 +13,7 @@ from rdkit.Chem.Descriptors import ExactMolWt
 from glyles.glycans.factory.factory import MonomerFactory
 from glyles.glycans.mono.reactor import functional_groups
 from glyles.glycans.mono.monomer import Monomer
+from glyles.glycans.poly.anltr_error_listener import GlyLESErrorListener
 from glyles.glycans.poly.merger import Merger
 from glyles.glycans.poly.viz import Tree
 from glyles.glycans.poly.walker import TreeWalker
@@ -413,17 +413,6 @@ class Glycan:
             Nothing
         """
         try:
-            # catch the prints of antlr to stderr to check if during parsing an error occurred and the glycan is invalid
-            log = []
-
-            class Writer(object):
-                @staticmethod
-                def write(data):
-                    log.append(data)
-
-            old_err = sys.stderr
-            sys.stderr = Writer()
-
             # parse the remaining structure description following the grammar, also add the dummy characters
             if not isinstance(self.iupac, str):
                 raise ParseError("Only string input can be parsed: " + str(self.iupac))
@@ -431,15 +420,17 @@ class Glycan:
             lexer = GlycanLexer(stream)
             token = CommonTokenStream(lexer)
             parser = GlycanParser(token)
-            self.grammar_tree = parser.start()
+            lexer.removeErrorListeners()
+            parser.removeErrorListeners()
+            lexer.addErrorListener(GlyLESErrorListener())
+            parser.addErrorListener(GlyLESErrorListener())
 
-            sys.stderr = old_err
-
-            # if the glycan is invalid, set its structure to None and the SMILES string to empty and return
-            if len(log) != 0:
+            try:
+                self.grammar_tree = parser.start()
+            except ParseError as pe:
                 self.parse_tree = None
                 self.glycan_smiles = ""
-                raise ParseError("Glycan cannot be parsed:\n" + log[0])
+                raise pe from None
 
             # walk through the AST and parse the AST into a networkx representation of the glycan.
             self.parse_tree, self.tree_full = TreeWalker(self.factory, self.tree_only).parse(self.grammar_tree)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -433,3 +433,9 @@ class TestParser:
         check_child(g, id_child_1, id_child_21, "Alt", "(a1-2)", 0, Lactole.PYRANOSE)
         check_child(g, id_child_1, id_child_22, "Glc", "(a1-4)", 0, Lactole.PYRANOSE)
         check_child(g, id_child_1, id_child_23, "Gal", "(a1-6)", 0, Lactole.PYRANOSE)
+
+    def test_parsing_error(self, caplog):
+        iupac = "Alt(a1-2)[Glc(a1-4)][Gal(a1-6)]Gul(a1-4)M*#$s'\d ;«]as;an"  # Invalid IUPAC string!
+        g = Glycan(iupac).get_tree()
+        assert g is None
+        assert "A parsing error occurred" in caplog.records[0].msg


### PR DESCRIPTION
First congratulations on GlyLES!

Not only it is a very valuable tool for the conversion between iupac notations and SMILES, but the implementation with a formal grammar and the quality of the python code (on PyPI, with tests, using modern tools like poetry) is outstanding: so rare to see in academia!

As a minor suggestions I suggest adopting a custom error listener instead of looking for lexer/parser error in stderr.